### PR TITLE
Add parts and checkout pages.

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -13,6 +13,10 @@ h1 {
     color: white;
 }
 
+h3 {
+    text-align: center;
+}
+
 .header-links {
     text-decoration: none;
     background-color: slategray;
@@ -72,4 +76,56 @@ h1 {
 
 .weight-elt {
     display: block;
+}
+
+.part-info {
+    margin: auto;
+    width: 95%;
+    color: white;
+    text-align: center;
+}
+
+.part {
+    border-style: double;
+    border-width: 5px;
+    border-color: steelblue;
+    color: white;
+    text-align: center;
+}
+
+.cart {
+    margin: auto;
+    width: 95%;
+    color: white;
+}
+
+.cart-part {
+    border-style: double;
+    border-width: 5px;
+    border-color: steelblue;
+    color: white;
+}
+
+.product-info {
+    text-align: left;
+    white-space: pre;
+}
+
+.order-box {
+    white-space: pre;
+}
+
+.cart-box {
+    color: white;
+    margin: auto;
+    width: 50%;
+    border-style: solid;
+    border-width: 10px;
+    border-color: steelblue;
+    white-space: pre;
+    text-align: left;
+}
+
+.order-footer {
+    text-align: center;
 }

--- a/checkout.php
+++ b/checkout.php
@@ -1,0 +1,88 @@
+<?php
+    try {// if something goes wrong, an exception is thrown
+        $dsn = "mysql:host=blitz;dbname=csci467";
+        $pdo = new PDO($dsn, 'student', 'student');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+    }
+    catch(PDOexception $e)  { // handle that exception
+        $pdo = false;
+    }
+
+    //Initialize the webpage with the appropriate statements to print the header and import relevant functions.
+    session_start();
+    require './src/functions.php';
+    printHeader();
+
+    //TODO: Finalize logic for placing an order, to include credit card authorization, deducting item quantity from
+    //the new database, etc.
+    if(isset($_POST['orderPlaced']))
+    {
+        unset($_SESSION['cart']);
+    }
+
+    //Set this page as the return page from the login page.
+    $_SESSION['ReturnPage'] = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['SERVER_NAME'] . $_SERVER['PHP_SELF'] .
+    '?' . $_SERVER['QUERY_STRING'];
+
+    //Display the current cart.
+    echo '<div class="cart-box">';
+
+    if(isset($_SESSION['cart'])) {
+        echo '<table class="cart">';
+        $items = array_keys($_SESSION['cart']);
+
+        //Initialize total weight and total price.
+        $totalWt = 0;
+        $totalPrice = 0;
+
+        //Display items in the current cart.
+        for($i = 0; $i < count($items); $i++) {
+
+            //If the last row ended, start a new row.
+            if($i % 3 == 0) {
+                echo '<tr class="cart-part">';
+            }
+
+            $result = $pdo->query("SELECT * FROM `parts` WHERE `number` = " . $items[$i] . ";");
+            $row = $result->fetch(PDO::FETCH_NUM);
+
+            //Compute the weight for the quantity of the current item, then add it to the total.
+            $itemWt = $row[3] * $_SESSION['cart'][$items[$i]];
+            $totalWt += $itemWt;
+
+            //Compute the price for the quantity of the current item, then add it to the total.
+            $itemPrice = $row[2] * $_SESSION['cart'][$items[$i]];
+            $totalPrice += $itemPrice;
+
+            echo '<td class="cart-part"><img src="' . $row[4] . "\" />\t";
+            echo "\nProduct: " . ucfirst($row[1])
+            . "\nQuantity in cart: " . $_SESSION['cart'][$items[$i]]
+            . "\nCombined item weight: " . $itemWt . ' lbs.</td>' . "\n";
+
+            //If there are now 3 products on a row, end this row.
+            if(($i + 1) % 3 == 0)
+            {
+                echo '</tr>';
+            }
+        }
+        
+        echo '</table>';
+
+        //TODO: Add logic for computing shipping cost.
+        echo '<div class="order-footer"><form method="POST" action="./checkout.php">' . "\nTotal Weight: " . $totalWt . ' lbs.';
+        echo "\nTotal Price: $" . $totalPrice;
+        echo '<input type="hidden" name="totPrice" value="' . $totalPrice . '"/>'
+        . '<input type="hidden" name="totWt" value="' . $totalWt . '"/>'
+        . "\n" . '<input type="submit" value="Place Order" name="orderPlaced" />';
+        echo '</form></div>';
+    }
+
+    else {
+        echo '<h3>Your cart is empty.</h3>';
+    }
+
+    //Close the body and html tags after running the relevant functions.
+    echo '
+    </body>
+</html>';
+?>

--- a/parts.php
+++ b/parts.php
@@ -1,0 +1,62 @@
+<?php
+
+    try {// if something goes wrong, an exception is thrown
+        $dsn = "mysql:host=blitz;dbname=csci467";
+        $pdo = new PDO($dsn, 'student', 'student');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+    }
+    catch(PDOexception $e)  { // handle that exception
+        $pdo = false;
+    }
+
+    //Initialize the webpage with the appropriate statements to print the header and import relevant functions.
+    session_start();
+    require './src/functions.php';
+    printHeader();
+
+    //Fetch the parts from the database.
+    $result = $pdo->query("SELECT * FROM `parts`;");
+
+    //Display the parts from the database in a table.
+    $colNum = 0;
+    echo
+  "   <table class=\"part-info\">\n";
+    while($row = $result->fetch(PDO::FETCH_NUM)) {
+        //If this is the first column, print a new tr tag.
+        if($colNum == 0) {
+            echo "\n<tr class=\"part\">";
+        }
+
+        //TODO: Fetch the quantity on-hand for the current product; set maximum quantity for add to cart.
+
+        //Print the data for the current database record."
+        echo "\n<td class=\"part\"><img class=\"product-pic\" src=\"" . $row[4] . "\" /><div class=\"product-info\">Product: "
+        . ucfirst($row[1]) ."\nPrice: $" . $row[2] . "\nWeight: " . $row[3] . " lbs.\nQuantity in store: " . "</div>"
+        . '<form method="POST" action="./parts.php"><input type="hidden" name="partNum" value="' . $row[0] . '"/>'
+        . '<input type="number" id="qtyOrdered" name="qtyOrdered" value="1" min="1" /><input type="submit" value="Add to Cart" name="itemAdd" />'
+        . "</form></td>";
+
+        $colNum++;
+
+        //If there are four columns on the current row, start a new row.
+        if($colNum == 4) {
+            echo "\n</tr>";
+            $colNum = 0;
+        }
+    }
+
+    //Set this page as the return page from the login page.
+    $_SESSION['ReturnPage'] = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['SERVER_NAME'] . $_SERVER['PHP_SELF'] .
+    '?' . $_SERVER['QUERY_STRING'];
+
+    //If the user added something to their cart, update the session variable appropriately.
+    if(isset($_POST['itemAdd']))
+    {
+        $_SESSION['cart'][$_POST['partNum']] = $_POST['qtyOrdered'];
+    }
+
+    //Close the body and html tags after running the relevant functions.
+    echo '
+    </body>
+</html>';
+?>

--- a/src/functions.php
+++ b/src/functions.php
@@ -43,6 +43,8 @@
                 }
 
                 echo '<a href="./index.php" title="Home Page" class="header-links">&#x1F3E0;</a>' . "\n";
+                echo '<a href="./parts.php" title="Products" class="header-links">&#x1FA9B;</a>' . "\n";
+                echo '<a href="./checkout.php" title="View Cart" class="header-links">&#x1F6D2;</a>' . "\n";
 
                 if(!isset($_SESSION['username'])) {
                     echo '<a href="./login.php" title="Login" class="header-links">&#x1F511;</a>';

--- a/weight.php
+++ b/weight.php
@@ -7,10 +7,6 @@
                 Minimum Weight:\
             </label>\
             <input type=\"text\" id=\"weight-min\" name=\"weight-min\" />\
-            <label for=\"weight-max\" class=\"weight-elt\">\
-                Maximum Weight:\
-            </label>\
-            <input type=\"text\" id=\"weight-max\" name=\"weight-max\" />\
             <label for=\"price\" class=\"weight-elt\">\
                 Price:\
             </label>\


### PR DESCRIPTION
The parts page displays all of the information about each part, except their number, and gives customers the ability to add items to their cart. Validating their input amount should be relatively straightforward, as number type inputs in HTML have a max option.

The checkout page simply clears the cart variable once an order is placed: further functionality will require the orders DB and credit card authorization system.

Minor tweaks to the weight bracket interface, removing the maximum weight option from the add new bracket screen.